### PR TITLE
getpubkey() has gone away from bitcoin DeterministicKey.  Need to

### DIFF
--- a/src/main/java/co/gem/round/coinop/MultiWallet.java
+++ b/src/main/java/co/gem/round/coinop/MultiWallet.java
@@ -147,7 +147,7 @@ public class MultiWallet {
   }
 
   public DeterministicKey childPrimaryPublicKeyFromPath(String path) {
-    return childKeyFromPath(path, this.primaryPrivateKey.getPubOnly());
+    return childKeyFromPath(path, this.primaryPrivateKey.dropPrivateBytes().dropParent());
   }
 
   public DeterministicKey childBackupPublicKeyFromPath(String path) {


### PR DESCRIPTION
dropPrivateBytes().dropParent() to get a clean pub key from one with
private info